### PR TITLE
Fixed 3 issues of type: PYTHON_W291 throughout 2 files in repo.

### DIFF
--- a/apps/TCPB_-_IOC_Parser/app.py
+++ b/apps/TCPB_-_IOC_Parser/app.py
@@ -30,8 +30,8 @@ class App(PlaybookApp):
         This method should be overridden with the output variables defined in the install.json
         configuration file.
         """
-        self.tcex.playbook.create_output('iocParser.asns', self.iocs['asns'], 'StringArray') 
-        self.tcex.playbook.create_output('iocParser.bitcoinAddresses', self.iocs['bitcoin_addresses'], 'StringArray') 
+        self.tcex.playbook.create_output('iocParser.asns', self.iocs['asns'], 'StringArray')
+        self.tcex.playbook.create_output('iocParser.bitcoinAddresses', self.iocs['bitcoin_addresses'], 'StringArray')
         self.tcex.playbook.create_output('iocParser.cves', self.iocs['cves'], 'StringArray')
         self.tcex.playbook.create_output('iocParser.domains', self.iocs['domains'], 'StringArray')
         self.tcex.playbook.create_output('iocParser.emailAddresses', self.iocs['email_addresses'], 'StringArray')

--- a/apps/TCPB_-_IP_Address_Utility/app.py
+++ b/apps/TCPB_-_IP_Address_Utility/app.py
@@ -12,7 +12,7 @@ class App(PlaybookApp):
 
     @staticmethod
     def _format_ipv6_for_tc(exploded_ipv6):
-        address_sections = [section.replace("0000", "xxxx").lstrip("0") for section in exploded_ipv6.split(":")] 
+        address_sections = [section.replace("0000", "xxxx").lstrip("0") for section in exploded_ipv6.split(":")]
         formatted_address_sections = ":".join(address_sections)
         return formatted_address_sections.replace("xxxx", "0")
 


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.