### PR TITLE
Fixed 3 issues of type: PYTHON_W293 throughout 1 file in repo.

### DIFF
--- a/apps/TCPB_-_URL_Utility/app.py
+++ b/apps/TCPB_-_URL_Utility/app.py
@@ -43,13 +43,13 @@ class App(PlaybookApp):
 
             if self.args.remove_query_strings:
                 url = url.replace('?{}'.format(parsed_url.query), '')
-            
+
             if self.args.remove_fragments:
                 url = url.replace('#{}'.format(parsed_url.fragment), '')
-            
+
             if self.args.remove_path:
                 url = url.replace(parsed_url.path, '')
-            
+
             self.updated_urls.append(url)
 
         # set the App exit message


### PR DESCRIPTION
PYTHON_W293: 'Remove trailing whitespace on blank line.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.