### PR TITLE
update polyswarm marketplace

### DIFF
--- a/apps/PolySwarm Marketplace/README.md
+++ b/apps/PolySwarm Marketplace/README.md
@@ -11,3 +11,6 @@ Changelog:
 ## 1.2.0
 * update dependencies tcex and polyswarm-api
 * fix various minor bugs
+
+## 1.2.4
+* update the hash search output variable `results.malicious_detections_str` to use the single malware family name from PolyUnite


### PR DESCRIPTION
Updates polyswarm to v1.2.4

Apologies for the multiple version jump. There is only one change since v1.2.0.

changelog:
* update the hash search output variable `results.malicious_detections_str` to use the single malware family name from PolyUnite